### PR TITLE
fix: OP_PUSHDATA2/4 length calculation in decode_push_datas

### DIFF
--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -283,7 +283,7 @@ impl InscriptionParser {
         if bytes.len() < 3 {
           return None;
         }
-        let len = ((bytes[1] as usize) << 8) + ((bytes[0] as usize) << 0);
+        let len = (bytes[1] as usize) + ((bytes[2] as usize) << 8);
         if bytes.len() < 3 + len {
           return None;
         }
@@ -297,10 +297,10 @@ impl InscriptionParser {
         if bytes.len() < 5 {
           return None;
         }
-        let len = ((bytes[3] as usize) << 24)
-          + ((bytes[2] as usize) << 16)
-          + ((bytes[1] as usize) << 8)
-          + ((bytes[0] as usize) << 0);
+        let len = (bytes[1] as usize)
+          + ((bytes[2] as usize) << 8)
+          + ((bytes[3] as usize) << 16)
+          + ((bytes[4] as usize) << 24);
         if bytes.len() < 5 + len {
           return None;
         }


### PR DESCRIPTION
## Summary

- Fix incorrect byte indices in `decode_push_datas()` OP_PUSHDATA2 and OP_PUSHDATA4 length calculations
- The opcode byte (`bytes[0]`) was used as part of the length instead of the actual length bytes

## The bug

```rust
// OP_PUSHDATA2 format: 0x4d <len_lo> <len_hi> <data...>

// Before (buggy): uses bytes[0] (opcode 0x4d=77) as low byte of length
let len = ((bytes[1] as usize) << 8) + ((bytes[0] as usize) << 0);

// After (fixed): reads length from bytes[1] and bytes[2]
let len = (bytes[1] as usize) + ((bytes[2] as usize) << 8);
```

For a 520-byte push: old code computed length as `(8 << 8) + 77 = 2125` instead of `8 + (2 << 8) = 520`, causing `decode_push_datas` to return `None`.

## Impact

Any inscription with data chunks > 255 bytes silently fails to index. This affects all inscriptions using standard 520-byte chunks (the max push data size). Existing Pepinals/doginals inscriptions are unaffected since they use 240-byte chunks (≤ 255, so OP_PUSHDATA1 only).

This bug exists in all forks of the apezord/ord-dogecoin codebase.

Fixes #4