### PR TITLE
Use page-based pagination for /inscriptions endpoint

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -79,9 +79,9 @@ pub struct InscriptionJson {
 
 #[derive(Serialize, Deserialize)]
 pub struct InscriptionsJson {
-  pub inscriptions: Vec<InscriptionId>,
-  pub prev: Option<u64>,
-  pub next: Option<u64>,
+  pub ids: Vec<InscriptionId>,
+  pub more: bool,
+  pub page_index: u64,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -1083,19 +1083,54 @@ impl Server {
     accept_json: AcceptJson,
     from: Option<u64>,
   ) -> ServerResult<Response> {
-    let (inscriptions, prev, next) = index.get_latest_inscriptions_with_prev_and_next(100, from)?;
+    let page_index = from.unwrap_or(0);
+    let count = index.inscription_count()?;
+
+    if page_index * 100 >= count {
+      if accept_json.0 {
+        return Ok(
+          Json(InscriptionsJson {
+            ids: Vec::new(),
+            more: false,
+            page_index,
+          })
+          .into_response(),
+        );
+      } else {
+        return Ok(
+          InscriptionsHtml {
+            inscriptions: Vec::new(),
+            page_index,
+            more: false,
+          }
+          .page(page_config, index.has_sat_index()?)
+          .into_response(),
+        );
+      }
+    }
+
+    let from = (count - 1) - page_index * 100;
+
+    let (inscriptions, prev, _next) =
+      index.get_latest_inscriptions_with_prev_and_next(100, Some(from))?;
+
+    let more = prev.is_some();
+
     if accept_json.0 {
-      Ok(Json(InscriptionsJson {
-        inscriptions,
-        prev,
-        next,
-      }).into_response())
+      Ok(
+        Json(InscriptionsJson {
+          ids: inscriptions,
+          more,
+          page_index,
+        })
+        .into_response(),
+      )
     } else {
       Ok(
         InscriptionsHtml {
           inscriptions,
-          next,
-          prev,
+          page_index,
+          more,
         }
         .page(page_config, index.has_sat_index()?)
         .into_response(),
@@ -2596,7 +2631,7 @@ mod tests {
   }
 
   #[test]
-  fn inscriptions_page_with_no_next() {
+  fn inscriptions_page_with_no_prev() {
     let server = TestServer::new_with_sat_index();
 
     for i in 0..101 {
@@ -2615,12 +2650,12 @@ mod tests {
     server.assert_response_regex(
       "/inscriptions",
       StatusCode::OK,
-      ".*<a class=prev href=/inscriptions/0>prev</a>\nnext.*",
+      ".*prev\n<a class=next href=/inscriptions/1>next</a>.*",
     );
   }
 
   #[test]
-  fn inscriptions_page_with_no_prev() {
+  fn inscriptions_page_with_no_next() {
     let server = TestServer::new_with_sat_index();
 
     for i in 0..101 {
@@ -2637,9 +2672,9 @@ mod tests {
     server.mine_blocks(1);
 
     server.assert_response_regex(
-      "/inscriptions/0",
+      "/inscriptions/1",
       StatusCode::OK,
-      ".*prev\n<a class=next href=/inscriptions/100>next</a>.*",
+      ".*<a class=prev href=/inscriptions/0>prev</a>\nnext.*",
     );
   }
 

--- a/src/templates/inscriptions.rs
+++ b/src/templates/inscriptions.rs
@@ -3,8 +3,8 @@ use super::*;
 #[derive(Boilerplate)]
 pub(crate) struct InscriptionsHtml {
   pub(crate) inscriptions: Vec<InscriptionId>,
-  pub(crate) prev: Option<u64>,
-  pub(crate) next: Option<u64>,
+  pub(crate) page_index: u64,
+  pub(crate) more: bool,
 }
 
 impl PageContent for InscriptionsHtml {
@@ -22,8 +22,8 @@ mod tests {
     assert_regex_match!(
       InscriptionsHtml {
         inscriptions: vec![inscription_id(1), inscription_id(2)],
-        prev: None,
-        next: None,
+        page_index: 0,
+        more: false,
       },
       "
         <h1>Inscription</h1>
@@ -45,8 +45,8 @@ mod tests {
     assert_regex_match!(
       InscriptionsHtml {
         inscriptions: vec![inscription_id(1), inscription_id(2)],
-        prev: Some(1),
-        next: Some(2),
+        page_index: 1,
+        more: true,
       },
       "
         <h1>Inscription</h1>
@@ -55,7 +55,7 @@ mod tests {
           <a href=/inscription/2{64}i2><iframe .* src=/preview/2{64}i2></iframe></a>
         </div>
         .*
-        <a class=prev href=/inscriptions/1>prev</a>
+        <a class=prev href=/inscriptions/0>prev</a>
         <a class=next href=/inscriptions/2>next</a>
         .*
       "

--- a/templates/inscriptions.html
+++ b/templates/inscriptions.html
@@ -5,13 +5,13 @@
 %% }
 </div>
 <div class=center>
-%% if let Some(prev) = self.prev {
-<a class=prev href=/inscriptions/{{prev}}>prev</a>
+%% if self.page_index > 0 {
+<a class=prev href=/inscriptions/{{self.page_index - 1}}>prev</a>
 %% } else {
 prev
 %% }
-%% if let Some(next) = self.next {
-<a class=next href=/inscriptions/{{next}}>next</a>
+%% if self.more {
+<a class=next href=/inscriptions/{{self.page_index + 1}}>next</a>
 %% } else {
 next
 %% }


### PR DESCRIPTION
## Summary
- Update `/inscriptions` JSON response to match upstream format: `ids`, `more`, `page_index` instead of `inscriptions`, `prev`, `next`
- Update HTML pagination to use page numbers (`/inscriptions/0`, `/inscriptions/1`, ...) instead of inscription numbers
- Update `InscriptionsHtml` template and tests

## JSON response format
```json
{
  "ids": ["abc...i0", "def...i0"],
  "more": true,
  "page_index": 0
}
```

## Test plan
- [x] All 281 lib tests pass
- [x] All 81 integration tests pass