### PR TITLE
Add integration tests for JSON API endpoints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ macro_rules! tprintln {
     };
 }
 
-pub(crate) mod api;
+pub mod api;
 mod arguments;
 mod blocktime;
 mod chain;

--- a/tests/json_api.rs
+++ b/tests/json_api.rs
@@ -1,0 +1,127 @@
+use super::*;
+
+#[test]
+fn status() {
+  let rpc_server = test_bitcoincore_rpc::spawn();
+  let test_server = TestServer::spawn_with_args(&rpc_server, &[]);
+
+  let response = test_server.json_request("/status");
+  assert_eq!(response.status(), StatusCode::OK);
+
+  let status: ord::api::Status = serde_json::from_str(&response.text().unwrap()).unwrap();
+  pretty_assert_eq!(status.chain, rpc_server.network());
+  assert!(status.height.is_some());
+  pretty_assert_eq!(status.inscriptions, 0);
+}
+
+#[test]
+fn inscriptions() {
+  let rpc_server = test_bitcoincore_rpc::spawn();
+  create_wallet(&rpc_server);
+  let inscribe = inscribe(&rpc_server);
+  let test_server = TestServer::spawn_with_args(&rpc_server, &[]);
+
+  let response = test_server.json_request("/inscriptions");
+  assert_eq!(response.status(), StatusCode::OK);
+
+  let inscriptions: ord::api::Inscriptions = serde_json::from_str(&response.text().unwrap()).unwrap();
+  pretty_assert_eq!(inscriptions.ids, vec![inscribe.inscription.parse().unwrap()]);
+  assert!(!inscriptions.more);
+  pretty_assert_eq!(inscriptions.page_index, 0);
+}
+
+#[test]
+fn inscription() {
+  let rpc_server = test_bitcoincore_rpc::spawn();
+  create_wallet(&rpc_server);
+  let inscribe = inscribe(&rpc_server);
+  let test_server = TestServer::spawn_with_args(&rpc_server, &[]);
+
+  let response = test_server.json_request(format!("/inscription/{}", inscribe.inscription));
+  assert_eq!(response.status(), StatusCode::OK);
+
+  let inscription: ord::api::Inscription = serde_json::from_str(&response.text().unwrap()).unwrap();
+  pretty_assert_eq!(inscription.id, inscribe.inscription.parse().unwrap());
+  pretty_assert_eq!(inscription.number, 0);
+  pretty_assert_eq!(inscription.height, 2);
+}
+
+#[test]
+fn inscriptions_batch() {
+  let rpc_server = test_bitcoincore_rpc::spawn();
+  create_wallet(&rpc_server);
+  let inscribe = inscribe(&rpc_server);
+  let test_server = TestServer::spawn_with_args(&rpc_server, &[]);
+
+  let response = test_server.post_json("/inscriptions", &vec![inscribe.inscription.clone()]);
+  assert_eq!(response.status(), StatusCode::OK);
+
+  let inscriptions: Vec<ord::api::Inscription> = serde_json::from_str(&response.text().unwrap()).unwrap();
+  pretty_assert_eq!(inscriptions.len(), 1);
+  pretty_assert_eq!(inscriptions[0].id, inscribe.inscription.parse().unwrap());
+}
+
+#[test]
+fn output() {
+  let rpc_server = test_bitcoincore_rpc::spawn();
+  create_wallet(&rpc_server);
+  let inscribe = inscribe(&rpc_server);
+  let test_server = TestServer::spawn_with_args(&rpc_server, &[]);
+
+  let outpoint = OutPoint::new(inscribe.reveal, 0);
+
+  let response = test_server.json_request(format!("/output/{outpoint}"));
+  assert_eq!(response.status(), StatusCode::OK);
+
+  let output: ord::api::Output = serde_json::from_str(&response.text().unwrap()).unwrap();
+  pretty_assert_eq!(output.outpoint, outpoint);
+  pretty_assert_eq!(output.value, 100000);
+}
+
+#[test]
+fn outputs_batch() {
+  let rpc_server = test_bitcoincore_rpc::spawn();
+  create_wallet(&rpc_server);
+  let inscribe = inscribe(&rpc_server);
+  let test_server = TestServer::spawn_with_args(&rpc_server, &[]);
+
+  let outpoint = OutPoint::new(inscribe.reveal, 0);
+
+  let response = test_server.post_json("/outputs", &vec![outpoint.to_string()]);
+  assert_eq!(response.status(), StatusCode::OK);
+
+  let outputs: Vec<ord::api::Output> = serde_json::from_str(&response.text().unwrap()).unwrap();
+  pretty_assert_eq!(outputs.len(), 1);
+  pretty_assert_eq!(outputs[0].outpoint, outpoint);
+}
+
+#[test]
+fn outputs_batch_unknown() {
+  let rpc_server = test_bitcoincore_rpc::spawn();
+  let test_server = TestServer::spawn_with_args(&rpc_server, &[]);
+
+  let unknown_outpoint = "0000000000000000000000000000000000000000000000000000000000000000:0";
+  let response = test_server.post_json("/outputs", &vec![unknown_outpoint]);
+  assert_eq!(response.status(), StatusCode::OK);
+
+  let outputs: Vec<ord::api::Output> = serde_json::from_str(&response.text().unwrap()).unwrap();
+  pretty_assert_eq!(outputs.len(), 1);
+  pretty_assert_eq!(outputs[0].outpoint, unknown_outpoint.parse().unwrap());
+  assert!(!outputs[0].indexed);
+}
+
+#[test]
+fn block() {
+  let rpc_server = test_bitcoincore_rpc::spawn();
+  let test_server = TestServer::spawn_with_args(&rpc_server, &[]);
+
+  let blocks = rpc_server.mine_blocks(1);
+  let hash = blocks[0].block_hash();
+
+  let response = test_server.json_request("/block/1");
+  assert_eq!(response.status(), StatusCode::OK);
+
+  let block: ord::api::Block = serde_json::from_str(&response.text().unwrap()).unwrap();
+  pretty_assert_eq!(block.hash, hash);
+  pretty_assert_eq!(block.height, 1);
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -97,6 +97,7 @@ mod expected;
 mod find;
 mod index;
 mod info;
+mod json_api;
 mod list;
 mod parse;
 mod server;

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -24,7 +24,8 @@ impl TestServer {
       .port();
 
     let child = Command::new(executable_path("ord-pepecoin")).args(format!(
-      "--rpc-url {} --pepecoin-data-dir {} --data-dir {} {} server --http-port {port} --address 127.0.0.1",
+      "--chain {} --rpc-url {} --pepecoin-data-dir {} --data-dir {} {} server --http-port {port} --address 127.0.0.1",
+      rpc_server.network(),
       rpc_server.url(),
       tempdir.path().display(),
       tempdir.path().display(),
@@ -68,7 +69,7 @@ impl TestServer {
       assert_eq!(response.status(), StatusCode::OK);
       if response.text().unwrap().parse::<u64>().unwrap() == chain_block_count {
         break;
-      } else if i == 20 {
+      } else if i == 200 {
         panic!("index failed to synchronize with chain");
       }
       thread::sleep(Duration::from_millis(25));
@@ -88,13 +89,57 @@ impl TestServer {
       assert_eq!(response.status(), StatusCode::OK);
       if response.text().unwrap().parse::<u64>().unwrap() == chain_block_count {
         break;
-      } else if i == 20 {
+      } else if i == 200 {
         panic!("index failed to synchronize with chain");
       }
       thread::sleep(Duration::from_millis(25));
     }
 
     reqwest::blocking::get(self.url().join(path.as_ref()).unwrap()).unwrap()
+  }
+
+  pub(crate) fn json_request(&self, path: impl AsRef<str>) -> Response {
+    let client = Client::new(&self.rpc_url, Auth::None).unwrap();
+    let chain_block_count = client.get_block_count().unwrap() + 1;
+
+    for i in 0.. {
+      let response = reqwest::blocking::get(self.url().join("/blockcount").unwrap()).unwrap();
+      assert_eq!(response.status(), StatusCode::OK);
+      if response.text().unwrap().parse::<u64>().unwrap() == chain_block_count {
+        break;
+      } else if i == 200 {
+        panic!("index failed to synchronize with chain");
+      }
+      thread::sleep(Duration::from_millis(25));
+    }
+
+    reqwest::blocking::Client::new()
+      .get(self.url().join(path.as_ref()).unwrap())
+      .header(reqwest::header::ACCEPT, "application/json")
+      .send()
+      .unwrap()
+  }
+
+  pub(crate) fn post_json(&self, path: impl AsRef<str>, body: &impl serde::Serialize) -> Response {
+    let client = Client::new(&self.rpc_url, Auth::None).unwrap();
+    let chain_block_count = client.get_block_count().unwrap() + 1;
+
+    for i in 0.. {
+      let response = reqwest::blocking::get(self.url().join("/blockcount").unwrap()).unwrap();
+      assert_eq!(response.status(), StatusCode::OK);
+      if response.text().unwrap().parse::<u64>().unwrap() == chain_block_count {
+        break;
+      } else if i == 200 {
+        panic!("index failed to synchronize with chain");
+      }
+      thread::sleep(Duration::from_millis(25));
+    }
+
+    reqwest::blocking::Client::new()
+      .post(self.url().join(path.as_ref()).unwrap())
+      .json(body)
+      .send()
+      .unwrap()
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `tests/json_api.rs` with 8 integration tests covering all JSON API endpoints
- Add `json_request()` and `post_json()` helpers to `TestServer`
- Make `api` module public for integration test access

### Tests added
- `GET /status` (JSON)
- `GET /inscriptions` (JSON)
- `GET /inscription/:id` (JSON)
- `POST /inscriptions` (batch)
- `GET /output/:outpoint` (JSON)
- `POST /outputs` (batch)
- `POST /outputs` with unknown outpoint
- `GET /block/:height` (JSON)

Prerequisite for axum upgrade (#10).

## Test plan
- [x] All 8 new tests pass
- [x] All 12 existing server tests pass