### PR TITLE
Add HTML status page

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -10,7 +10,7 @@ use {
     AddressHtml, BlockHtml, HomeHtml, InputHtml, InscriptionHtml, InscriptionsHtml, OutputHtml,
  PageContent,
     PageHtml, PreviewAudioHtml, PreviewImageHtml, PreviewPdfHtml, PreviewTextHtml,
-    PreviewUnknownHtml, PreviewVideoHtml, RangeHtml, RareTxt, SatHtml, TransactionHtml,
+    PreviewUnknownHtml, PreviewVideoHtml, RangeHtml, RareTxt, SatHtml, StatusHtml, TransactionHtml,
   },
   axum::{
     body::Body,
@@ -737,28 +737,36 @@ impl Server {
     Extension(index): Extension<Arc<Index>>,
     accept_json: AcceptJson,
   ) -> ServerResult<Response> {
+    let height = index.block_count().ok();
+    let inscriptions = index.inscription_count().unwrap_or(0);
+    let sat_index = index.has_sat_index().unwrap_or(false);
+    let unrecoverably_reorged = index.is_unrecoverably_reorged();
+
     if accept_json.0 {
       Ok(
         Json(api::Status {
           address_index: true,
           chain: page_config.chain.to_string(),
-          height: index.block_count().ok(),
-          inscriptions: index.inscription_count().unwrap_or(0),
-          sat_index: index.has_sat_index().unwrap_or(false),
-          unrecoverably_reorged: index.is_unrecoverably_reorged(),
+          height,
+          inscriptions,
+          sat_index,
+          unrecoverably_reorged,
         })
         .into_response(),
       )
-    } else if index.is_unrecoverably_reorged() {
-      Ok(
-        (
-          StatusCode::OK,
-          "unrecoverable reorg detected, please rebuild the database.",
-        )
-          .into_response(),
-      )
     } else {
-      Ok((StatusCode::OK, "OK").into_response())
+      Ok(
+        StatusHtml {
+          address_index: true,
+          chain: page_config.chain,
+          height,
+          inscriptions,
+          sat_index,
+          unrecoverably_reorged,
+        }
+        .page(page_config, sat_index)
+        .into_response(),
+      )
     }
   }
 
@@ -1669,7 +1677,7 @@ mod tests {
 
   #[test]
   fn status() {
-    TestServer::new().assert_response("/status", StatusCode::OK, "OK");
+    TestServer::new().assert_response_regex("/status", StatusCode::OK, ".*<h1>Status</h1>.*");
   }
 
   #[test]

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -17,6 +17,7 @@ pub(crate) use {
   range::RangeHtml,
   rare::RareTxt,
   sat::SatHtml,
+  status::StatusHtml,
   transaction::TransactionHtml,
 };
 
@@ -32,6 +33,7 @@ mod preview;
 mod range;
 mod rare;
 mod sat;
+mod status;
 mod transaction;
 
 #[derive(Boilerplate)]

--- a/src/templates/status.rs
+++ b/src/templates/status.rs
@@ -1,0 +1,17 @@
+use super::*;
+
+#[derive(Boilerplate)]
+pub(crate) struct StatusHtml {
+  pub(crate) address_index: bool,
+  pub(crate) chain: Chain,
+  pub(crate) height: Option<u64>,
+  pub(crate) inscriptions: u64,
+  pub(crate) sat_index: bool,
+  pub(crate) unrecoverably_reorged: bool,
+}
+
+impl PageContent for StatusHtml {
+  fn title(&self) -> String {
+    "Status".into()
+  }
+}

--- a/templates/status.html
+++ b/templates/status.html
@@ -1,0 +1,19 @@
+<h1>Status</h1>
+<dl>
+  <dt>chain</dt>
+  <dd>{{ self.chain }}</dd>
+%% if let Some(height) = self.height {
+  <dt>height</dt>
+  <dd><a href=/block/{{ height }}>{{ height }}</a></dd>
+%% }
+  <dt>inscriptions</dt>
+  <dd><a href=/inscriptions>{{ self.inscriptions }}</a></dd>
+  <dt>version</dt>
+  <dd>{{ env!("CARGO_PKG_VERSION") }}</dd>
+  <dt>unrecoverably reorged</dt>
+  <dd>{{ self.unrecoverably_reorged }}</dd>
+  <dt>address index</dt>
+  <dd>{{ self.address_index }}</dd>
+  <dt>sat index</dt>
+  <dd>{{ self.sat_index }}</dd>
+</dl>


### PR DESCRIPTION
## Summary
- Add HTML status page at `/status` matching upstream pattern
- Shows chain, height, inscriptions, version, reorg status, address/sat index
- JSON response unchanged

## Test plan
- [x] Unit test updated and passing