### PR TITLE
Rename ord-pepecoin to ordpep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2141,7 +2141,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "ord-pepecoin"
+name = "ordpep"
 version = "0.5.1"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ord-pepecoin"
+name = "ordpep"
 description = "◉ Ordinal wallet and block explorer for pepecoin"
 version = "0.5.1"
 license = "CC0-1.0"
@@ -68,7 +68,7 @@ test-bitcoincore-rpc = { path = "test-bitcoincore-rpc" }
 unindent = "0.2.1"
 
 [[bin]]
-name = "ord-pepecoin"
+name = "ordpep"
 path = "src/bin/main.rs"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ord-pepecoin
+# ordpep
 
 Ordinal indexer and block explorer for **Pepecoin**, forked from [apezord/ord-dogecoin](https://github.com/apezord/ord-dogecoin) (based on [ordinals/ord](https://github.com/ordinals/ord) v0.5.1).
 
@@ -17,30 +17,30 @@ cd ord-pepecoin
 cargo build --release
 ```
 
-The binary is at `./target/release/ord-pepecoin`.
+The binary is at `./target/release/ordpep`.
 
 ## Configuration
 
-`ord-pepecoin` can be configured with command-line flags, a YAML configuration file, or both. Command-line flags take precedence over the configuration file.
+`ordpep` can be configured with command-line flags, a YAML configuration file, or both. Command-line flags take precedence over the configuration file.
 
 ### Configuration file
 
-Create an `ord.yaml` file:
+Create an `ordpep.yaml` file:
 
 ```yaml
 pepecoin_rpc_username: "your_rpc_user"
 pepecoin_rpc_password: "your_rpc_password"
 rpc_url: "127.0.0.1:33873"
-data_dir: "/data/ord-pepecoin"
-index: "/data/ord-pepecoin/index.redb"
+data_dir: "/data/ordpep"
+index: "/data/ordpep/index.redb"
 ```
 
 The configuration file is loaded from the first location found:
 
 1. `--config <path>` — explicit path (errors if not found)
-2. `--config-dir <dir>/ord.yaml`
-3. `--data-dir <dir>/ord.yaml`
-4. Default data directory (`ord.yaml`)
+2. `--config-dir <dir>/ordpep.yaml`
+3. `--data-dir <dir>/ordpep.yaml`
+4. Default data directory (`ordpep.yaml`)
 
 All configuration file fields are optional:
 
@@ -50,7 +50,7 @@ All configuration file fields are optional:
 | `pepecoin_rpc_password` | RPC password (alternative to cookie auth) |
 | `rpc_url` | Pepecoin Core RPC URL |
 | `pepecoin_data_dir` | Pepecoin Core data directory |
-| `data_dir` | ord-pepecoin data directory |
+| `data_dir` | ordpep data directory |
 | `index` | Path to the index database |
 | `index_sats` | Track location of all satoshis (`true`/`false`) |
 | `cookie_file` | Path to RPC cookie file |
@@ -69,27 +69,27 @@ RPC authentication is resolved in this order:
 ### With a configuration file
 
 ```bash
-ord-pepecoin --config /path/to/ord.yaml server --http-port 3080
-ord-pepecoin --config /path/to/ord.yaml index update
+ordpep --config /path/to/ordpep.yaml server --http-port 3080
+ordpep --config /path/to/ordpep.yaml index update
 ```
 
 ### With command-line flags
 
 ```bash
-ord-pepecoin --rpc-url 127.0.0.1:33873 --cookie-file ~/.pepecoin/.cookie server --http-port 3080
-ord-pepecoin --rpc-url 127.0.0.1:33873 --cookie-file ~/.pepecoin/.cookie index update
+ordpep --rpc-url 127.0.0.1:33873 --cookie-file ~/.pepecoin/.cookie server --http-port 3080
+ordpep --rpc-url 127.0.0.1:33873 --cookie-file ~/.pepecoin/.cookie index update
 ```
 
 ### Export inscriptions to TSV
 
 ```bash
-ord-pepecoin index export --include-addresses > inscriptions.tsv
+ordpep index export --include-addresses > inscriptions.tsv
 ```
 
 ### Compact the database
 
 ```bash
-ord-pepecoin index compact
+ordpep index compact
 ```
 
 ### JSON API
@@ -137,16 +137,16 @@ The indexer automatically creates database savepoints near the chain tip. If a b
 
 ## Wallet
 
-`ord-pepecoin` relies on Pepecoin Core for private key management and transaction signing.
+`ordpep` relies on Pepecoin Core for private key management and transaction signing.
 
-- Pepecoin Core is not aware of inscriptions and does not perform sat control. Using `pepecoin-cli` commands with `ord-pepecoin` wallets may lead to loss of inscriptions.
+- Pepecoin Core is not aware of inscriptions and does not perform sat control. Using `pepecoin-cli` commands with `ordpep` wallets may lead to loss of inscriptions.
 - Keep ordinal and cardinal wallets segregated.
 
 ### Inscribing
 
 ```bash
-ord-pepecoin --config /path/to/ord.yaml wallet inscribe /path/to/file.png
-ord-pepecoin --config /path/to/ord.yaml wallet inscribe --dry-run /path/to/file.png
+ordpep --config /path/to/ordpep.yaml wallet inscribe /path/to/file.png
+ordpep --config /path/to/ordpep.yaml wallet inscribe --dry-run /path/to/file.png
 ```
 
 Inscriptions use P2SH `script_sig` transactions (Pepecoin has no SegWit). Large files are split across multiple chained transactions using 240-byte data chunks. Reveal transactions are signed locally.

--- a/bin/package
+++ b/bin/package
@@ -5,14 +5,14 @@ set -euxo pipefail
 VERSION=${REF#"refs/tags/"}
 DIST=`pwd`/dist
 
-echo "Packaging ord-pepecoin $VERSION for $TARGET..."
+echo "Packaging ordpep $VERSION for $TARGET..."
 
 test -f Cargo.lock || cargo generate-lockfile
 
-echo "Building ord-pepecoin..."
+echo "Building ordpep..."
 RUSTFLAGS="--deny warnings $TARGET_RUSTFLAGS" \
-  cargo build --bin ord-pepecoin --target $TARGET --release
-EXECUTABLE=target/$TARGET/release/ord-pepecoin
+  cargo build --bin ordpep --target $TARGET --release
+EXECUTABLE=target/$TARGET/release/ordpep
 
 if [[ $OS == windows-latest ]]; then
   EXECUTABLE=$EXECUTABLE.exe
@@ -32,13 +32,13 @@ cd $DIST
 echo "Creating release archive..."
 case $OS in
   ubuntu-latest | macos-latest)
-    ARCHIVE=$DIST/ord-pepecoin-$VERSION-$TARGET.tar.gz
+    ARCHIVE=$DIST/ordpep-$VERSION-$TARGET.tar.gz
     tar czf $ARCHIVE *
     echo "::set-output name=archive::$ARCHIVE"
     ;;
   windows-latest)
-    ARCHIVE=$DIST/ord-pepecoin-$VERSION-$TARGET.zip
+    ARCHIVE=$DIST/ordpep-$VERSION-$TARGET.zip
     7z a $ARCHIVE *
-    echo "::set-output name=archive::`pwd -W`/ord-pepecoin-$VERSION-$TARGET.zip"
+    echo "::set-output name=archive::`pwd -W`/ordpep-$VERSION-$TARGET.zip"
     ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ EOF
 }
 
 git=mvdnbrk/ord-pepecoin
-crate=ord-pepecoin
+crate=ordpep
 url=https://github.com/mvdnbrk/ord-pepecoin
 releases=$url/releases
 

--- a/ordpep.yaml.example
+++ b/ordpep.yaml.example
@@ -1,8 +1,8 @@
-# ord-pepecoin configuration
-# Copy this file to your data directory as ord.yaml
+# ordpep configuration
+# Copy this file to your data directory as ordpep.yaml
 # Default locations:
-#   Linux: ~/.local/share/ord-pepecoin/ord.yaml
-#   macOS: ~/Library/Application Support/ord-pepecoin/ord.yaml
+#   Linux: ~/.local/share/ordpep/ordpep.yaml
+#   macOS: ~/Library/Application Support/ordpep/ordpep.yaml
 # Or specify with: --config <path> or --config-dir <dir>
 
 # Pepecoin Core RPC connection
@@ -13,11 +13,11 @@
 #cookie_file: /path/to/.cookie
 
 # Index settings
-#data_dir: /path/to/ord-pepecoin/data
+#data_dir: /path/to/ordpep/data
 #index: /path/to/index.redb
 #index_sats: false
 
-# Server: where `ord-pepecoin server` listens
+# Server: where `ordpep server` listens
 #http_port: 8383
 #address: "127.0.0.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ pub fn main() {
       .iter()
       .for_each(|handle| handle.graceful_shutdown(Some(Duration::from_secs(5))));
 
-    println!("Detected Ctrl-C, attempting to shut down ord-pepecoin gracefully. Press Ctrl-C {INTERRUPT_LIMIT} times to force shutdown.");
+    println!("Detected Ctrl-C, attempting to shut down ordpep gracefully. Press Ctrl-C {INTERRUPT_LIMIT} times to force shutdown.");
 
     let interrupts = INTERRUPTS.fetch_add(1, atomic::Ordering::Relaxed);
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -45,7 +45,7 @@ pub struct Options {
   pub(crate) testnet: bool,
   #[clap(long, default_value = "ord", help = "Use wallet named <WALLET>.")]
   pub(crate) wallet: String,
-  #[clap(long, help = "Use ord-pepecoin server running at <SERVER_URL>.")]
+  #[clap(long, help = "Use ordpep server running at <SERVER_URL>.")]
   pub(crate) server_url: Option<Url>,
 }
 
@@ -103,9 +103,9 @@ impl Options {
       None => {
         // Check --config-dir, then --data-dir CLI flag, then default data dir
         let candidates = [
-          self.config_dir.as_ref().map(|d| d.join("ord.yaml")),
-          self.data_dir.as_ref().map(|d| d.join("ord.yaml")),
-          dirs::data_dir().map(|d| d.join("ord-pepecoin").join("ord.yaml")),
+          self.config_dir.as_ref().map(|d| d.join("ordpep.yaml")),
+          self.data_dir.as_ref().map(|d| d.join("ordpep.yaml")),
+          dirs::data_dir().map(|d| d.join("ordpep").join("ordpep.yaml")),
         ];
 
         for candidate in candidates.iter().flatten() {
@@ -142,7 +142,7 @@ impl Options {
       .server_url
       .clone()
       .or(config.server_url)
-      .ok_or_else(|| anyhow!("server URL not specified. Set --server-url or server_url in ord.yaml"))
+      .ok_or_else(|| anyhow!("server URL not specified. Set --server-url or server_url in ordpep.yaml"))
   }
 
   pub(crate) fn auth(&self) -> Result<Auth> {
@@ -193,7 +193,7 @@ impl Options {
       Some(base) => base,
       None => dirs::data_dir()
         .ok_or_else(|| anyhow!("failed to retrieve data dir"))?
-        .join("ord-pepecoin"),
+        .join("ordpep"),
     };
 
     Ok(self.chain().join_with_data_dir(&base))
@@ -248,7 +248,7 @@ impl Options {
     let ord_chain = self.chain();
 
     if rpc_chain != ord_chain {
-      bail!("Pepecoin RPC server is on {rpc_chain} but ord-pepecoin is on {ord_chain}");
+      bail!("Pepecoin RPC server is on {rpc_chain} but ordpep is on {ord_chain}");
     }
     Ok(client)
   }
@@ -405,7 +405,7 @@ mod tests {
       .display()
       .to_string();
     assert!(
-      data_dir.ends_with(if cfg!(windows) { r"\ord-pepecoin" } else { "/ord-pepecoin" }),
+      data_dir.ends_with(if cfg!(windows) { r"\ordpep" } else { "/ordpep" }),
       "{data_dir}"
     );
   }
@@ -421,9 +421,9 @@ mod tests {
       .to_string();
     assert!(
       data_dir.ends_with(if cfg!(windows) {
-        r"\ord-pepecoin\signet"
+        r"\ordpep\signet"
       } else {
-        "/ord-pepecoin/signet"
+        "/ordpep/signet"
       }),
       "{data_dir}"
     );
@@ -463,38 +463,38 @@ mod tests {
       assert!(data_dir.ends_with(suffix), "{data_dir}");
     }
 
-    check_network_alias("main", "ord-pepecoin");
-    check_network_alias("mainnet", "ord-pepecoin");
+    check_network_alias("main", "ordpep");
+    check_network_alias("mainnet", "ordpep");
     check_network_alias(
       "regtest",
       if cfg!(windows) {
-        r"ord-pepecoin\regtest"
+        r"ordpep\regtest"
       } else {
-        "ord-pepecoin/regtest"
+        "ordpep/regtest"
       },
     );
     check_network_alias(
       "signet",
       if cfg!(windows) {
-        r"ord-pepecoin\signet"
+        r"ordpep\signet"
       } else {
-        "ord-pepecoin/signet"
+        "ordpep/signet"
       },
     );
     check_network_alias(
       "test",
       if cfg!(windows) {
-        r"ord-pepecoin\testnet3"
+        r"ordpep\testnet3"
       } else {
-        "ord-pepecoin/testnet3"
+        "ordpep/testnet3"
       },
     );
     check_network_alias(
       "testnet",
       if cfg!(windows) {
-        r"ord-pepecoin\testnet3"
+        r"ordpep\testnet3"
       } else {
-        "ord-pepecoin/testnet3"
+        "ordpep/testnet3"
       },
     );
   }
@@ -521,7 +521,7 @@ mod tests {
 
     assert_eq!(
       options.pepecoin_rpc_client().unwrap_err().to_string(),
-      "Pepecoin RPC server is on testnet but ord-pepecoin is on mainnet"
+      "Pepecoin RPC server is on testnet but ordpep is on mainnet"
     );
   }
 
@@ -614,7 +614,7 @@ mod tests {
       .unwrap();
 
     let tempdir = TempDir::new().unwrap();
-    let path = tempdir.path().join("ord.yaml");
+    let path = tempdir.path().join("ordpep.yaml");
     fs::write(&path, format!("hidden:\n- \"{id}\"")).unwrap();
 
     assert_eq!(
@@ -639,7 +639,7 @@ mod tests {
     let tempdir = TempDir::new().unwrap();
 
     fs::write(
-      tempdir.path().join("ord.yaml"),
+      tempdir.path().join("ordpep.yaml"),
       format!("hidden:\n- \"{id}\""),
     )
     .unwrap();

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -123,7 +123,7 @@ pub struct Server {
   address: Option<String>,
   #[clap(
     long,
-    help = "Request ACME TLS certificate for <ACME_DOMAIN>. This ord-pepecoin instance must be reachable at <ACME_DOMAIN>:443 to respond to Let's Encrypt ACME challenges."
+    help = "Request ACME TLS certificate for <ACME_DOMAIN>. This ordpep instance must be reachable at <ACME_DOMAIN>:443 to respond to Let's Encrypt ACME challenges."
     )]
     pub(crate) acme_domain: Vec<String>,
   #[clap(
@@ -1312,7 +1312,7 @@ mod tests {
 
       let config_args = match config {
         Some(config) => {
-          let config_path = tempdir.path().join("ord.yaml");
+          let config_path = tempdir.path().join("ordpep.yaml");
           fs::write(&config_path, config).unwrap();
           format!("--config {}", config_path.display())
         }
@@ -1474,24 +1474,24 @@ mod tests {
   #[test]
   fn http_and_https_port_dont_conflict() {
     parse_server_args(
-      "ord-pepecoin server --http-port 0 --https-port 0 --acme-cache foo --acme-contact bar --acme-domain baz",
+      "ordpep server --http-port 0 --https-port 0 --acme-cache foo --acme-contact bar --acme-domain baz",
     );
   }
 
   #[test]
   fn http_port_defaults_to_80() {
-    assert_eq!(parse_server_args("ord-pepecoin server").1.http_port(&Config::default()), Some(80));
+    assert_eq!(parse_server_args("ordpep server").1.http_port(&Config::default()), Some(80));
   }
 
   #[test]
   fn https_port_defaults_to_none() {
-    assert_eq!(parse_server_args("ord-pepecoin server").1.https_port(), None);
+    assert_eq!(parse_server_args("ordpep server").1.https_port(), None);
   }
 
   #[test]
   fn https_sets_https_port_to_443() {
     assert_eq!(
-      parse_server_args("ord-pepecoin server --https --acme-cache foo --acme-contact bar --acme-domain baz")
+      parse_server_args("ordpep server --https --acme-cache foo --acme-contact bar --acme-domain baz")
         .1
         .https_port(),
       Some(443)
@@ -1501,7 +1501,7 @@ mod tests {
   #[test]
   fn https_disables_http() {
     assert_eq!(
-      parse_server_args("ord-pepecoin server --https --acme-cache foo --acme-contact bar --acme-domain baz")
+      parse_server_args("ordpep server --https --acme-cache foo --acme-contact bar --acme-domain baz")
         .1
         .http_port(&Config::default()),
       None
@@ -1512,7 +1512,7 @@ mod tests {
   fn https_port_disables_http() {
     assert_eq!(
       parse_server_args(
-        "ord-pepecoin server --https-port 433 --acme-cache foo --acme-contact bar --acme-domain baz"
+        "ordpep server --https-port 433 --acme-cache foo --acme-contact bar --acme-domain baz"
       )
       .1
       .http_port(&Config::default()),
@@ -1524,7 +1524,7 @@ mod tests {
   fn https_port_sets_https_port() {
     assert_eq!(
       parse_server_args(
-        "ord-pepecoin server --https-port 1000 --acme-cache foo --acme-contact bar --acme-domain baz"
+        "ordpep server --https-port 1000 --acme-cache foo --acme-contact bar --acme-domain baz"
       )
       .1
       .https_port(),
@@ -1536,7 +1536,7 @@ mod tests {
   fn http_with_https_leaves_http_enabled() {
     assert_eq!(
       parse_server_args(
-        "ord-pepecoin server --https --http --acme-cache foo --acme-contact bar --acme-domain baz"
+        "ordpep server --https --http --acme-cache foo --acme-contact bar --acme-domain baz"
       )
       .1
       .http_port(&Config::default()),
@@ -1548,7 +1548,7 @@ mod tests {
   fn http_with_https_leaves_https_enabled() {
     assert_eq!(
       parse_server_args(
-        "ord-pepecoin server --https --http --acme-cache foo --acme-contact bar --acme-domain baz"
+        "ordpep server --https --http --acme-cache foo --acme-contact bar --acme-domain baz"
       )
       .1
       .https_port(),
@@ -1621,7 +1621,7 @@ mod tests {
 
   #[test]
   fn acme_domain_defaults_to_hostname() {
-    let (_, server) = parse_server_args("ord-pepecoin server");
+    let (_, server) = parse_server_args("ordpep server");
     assert_eq!(
       server.acme_domains().unwrap(),
       &[sys_info::hostname().unwrap()]
@@ -1630,7 +1630,7 @@ mod tests {
 
   #[test]
   fn acme_domain_flag_is_respected() {
-    let (_, server) = parse_server_args("ord-pepecoin server --acme-domain example.com");
+    let (_, server) = parse_server_args("ordpep server --acme-domain example.com");
     assert_eq!(server.acme_domains().unwrap(), &["example.com"]);
   }
 
@@ -1953,7 +1953,7 @@ mod tests {
     test_server.assert_response_regex(
     "/",
     StatusCode::OK,
-    ".*<title>ord-pepecoin</title>.*
+    ".*<title>ordpep</title>.*
 <h2>Latest Blocks</h2>
 <ol start=1 reversed class=blocks>
   <li><a href=/block/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>
@@ -1967,7 +1967,7 @@ mod tests {
     TestServer::new().assert_response_regex(
       "/",
       StatusCode::OK,
-      ".*<a href=/>ord-pepecoin<sup>regtest</sup></a>.*",
+      ".*<a href=/>ordpep<sup>regtest</sup></a>.*",
     );
   }
 

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -134,7 +134,7 @@ mod tests {
   <body>
   <header>
     <nav>
-      <a href=/>ord-pepecoin<sup>beta</sup></a>
+      <a href=/>ordpep<sup>beta</sup></a>
       .*
       <a href=/rare.txt>rare.txt</a>
       <form action=/search method=get>
@@ -162,7 +162,7 @@ mod tests {
         }),
         true
       ),
-      r".*<nav>\s*<a href=/>ord-pepecoin<sup>beta</sup></a>.*"
+      r".*<nav>\s*<a href=/>ordpep<sup>beta</sup></a>.*"
     );
   }
 
@@ -176,7 +176,7 @@ mod tests {
         }),
         false
       ),
-      r".*<nav>\s*<a href=/>ord-pepecoin<sup>beta</sup></a>.*\s*<form action=/search.*",
+      r".*<nav>\s*<a href=/>ordpep<sup>beta</sup></a>.*\s*<form action=/search.*",
     );
   }
 
@@ -190,7 +190,7 @@ mod tests {
         }),
         true
       ),
-      r".*<nav>\s*<a href=/>ord-pepecoin<sup>signet</sup></a>.*"
+      r".*<nav>\s*<a href=/>ordpep<sup>signet</sup></a>.*"
     );
   }
 }

--- a/src/templates/home.rs
+++ b/src/templates/home.rs
@@ -23,7 +23,7 @@ impl HomeHtml {
 
 impl PageContent for HomeHtml {
   fn title(&self) -> String {
-    "ord-pepecoin".to_string()
+    "ordpep".to_string()
   }
 }
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -43,9 +43,9 @@ impl Wallet {
     let bitcoin_block_count = bitcoin_client.get_block_count()? + 1;
     loop {
       let response = ord_client.get(rpc_url.join("/blockcount")?).send()
-        .context("wallet failed to retrieve block count from server. Make sure `ord-pepecoin server` is running.")?;
+        .context("wallet failed to retrieve block count from server. Make sure `ordpep server` is running.")?;
       if !response.status().is_success() {
-        bail!("failed to get blockcount from ord-pepecoin server: {}", response.status());
+        bail!("failed to get blockcount from ordpep server: {}", response.status());
       }
       let ord_block_count: u64 = response.text()?.parse()?;
       if ord_block_count >= bitcoin_block_count {
@@ -111,14 +111,14 @@ impl Wallet {
     let outpoints: Vec<OutPoint> = utxos.keys().cloned().collect();
     let response = ord_client.post(rpc_url.join("/outputs")?).json(&outpoints).send()?;
     if !response.status().is_success() {
-      bail!("failed to get outputs from ord-pepecoin server: {}", response.status());
+      bail!("failed to get outputs from ordpep server: {}", response.status());
     }
     let response_outputs: Vec<api::Output> = response.json()?;
     let output_info: BTreeMap<OutPoint, api::Output> = outpoints.into_iter().zip(response_outputs).collect();
 
     for (outpoint, info) in &output_info {
       if !info.indexed {
-        bail!("output in Pepecoin Core wallet but not in ord-pepecoin index: {outpoint}");
+        bail!("output in Pepecoin Core wallet but not in ordpep index: {outpoint}");
       }
     }
 
@@ -127,7 +127,7 @@ impl Wallet {
     let (inscriptions, inscription_info) = if !inscription_ids.is_empty() {
       let response = ord_client.post(rpc_url.join("/inscriptions")?).json(&inscription_ids).send()?;
       if !response.status().is_success() {
-        bail!("failed to get inscriptions from ord-pepecoin server: {}", response.status());
+        bail!("failed to get inscriptions from ordpep server: {}", response.status());
       }
       let response_inscriptions: Vec<api::Inscription> = response.json()?;
       let mut inscriptions = BTreeMap::new();
@@ -144,7 +144,7 @@ impl Wallet {
     // Fetch status
     let response = ord_client.get(rpc_url.join("/status")?).send()?;
     if !response.status().is_success() {
-      bail!("failed to get status from ord-pepecoin server: {}", response.status());
+      bail!("failed to get status from ordpep server: {}", response.status());
     }
     let status: api::Status = response.json()?;
 
@@ -192,7 +192,7 @@ impl Wallet {
 
   pub(crate) fn get_unspent_output_ranges(&self) -> Result<Vec<(OutPoint, Vec<(u128, u128)>)>> {
     if !self.has_sat_index {
-      bail!("ord-pepecoin server does not have a sat index");
+      bail!("ordpep server does not have a sat index");
     }
     Ok(self.output_info
       .iter()

--- a/templates/page.html
+++ b/templates/page.html
@@ -16,7 +16,7 @@
   <body>
   <header>
     <nav>
-      <a href=/>ord-pepecoin<sup>{{ self.superscript() }}</sup></a>
+      <a href=/>ordpep<sup>{{ self.superscript() }}</sup></a>
       <a href=https://github.com/mvdnbrk/ord-pepecoin>GitHub</a>
 %% if self.has_sat_index {
       <a href=/rare.txt>rare.txt</a>

--- a/tests/command_builder.rs
+++ b/tests/command_builder.rs
@@ -99,7 +99,7 @@ impl CommandBuilder {
   }
 
   pub(crate) fn command(&self) -> Command {
-    let mut command = Command::new(executable_path("ord-pepecoin"));
+    let mut command = Command::new(executable_path("ordpep"));
 
     if let Some(rpc_server_url) = &self.rpc_server_url {
       let cookiefile = self.tempdir.path().join("cookie");

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -28,7 +28,7 @@ impl TestServer {
     std::env::set_var("ORD_INTEGRATION_TEST", "1");
 
     let (options, server) = parse_ord_server_args(&format!(
-      "ord-pepecoin --chain {} --rpc-url {} --cookie-file {} --pepecoin-data-dir {} --data-dir {} {} server --http-port 0 --address 127.0.0.1",
+      "ordpep --chain {} --rpc-url {} --cookie-file {} --pepecoin-data-dir {} --data-dir {} {} server --http-port 0 --address 127.0.0.1",
       rpc_server.network(),
       rpc_server.url(),
       cookiefile.to_str().unwrap(),

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -3,6 +3,6 @@ use super::*;
 #[test]
 fn version_flag_prints_version() {
   CommandBuilder::new("--version")
-    .stdout_regex("ord-pepecoin .*\n")
+    .stdout_regex("ordpep .*\n")
     .run();
 }


### PR DESCRIPTION
## Summary
- Rename binary from `ord-pepecoin` to `ordpep`
- Rename config file from `ord.yaml` to `ordpep.yaml`
- Update default data directory from `ord-pepecoin` to `ordpep`
- GitHub repo URLs unchanged

## Test plan
- [x] All integration tests pass with new binary name
- [x] `cargo build` produces `ordpep` binary