### PR TITLE
Validate content_type as MIME type, fix content_response panic

### DIFF
--- a/src/inscriptions/inscription.rs
+++ b/src/inscriptions/inscription.rs
@@ -212,7 +212,7 @@ impl Inscription {
     if self.delegate_id().is_some() {
       return None;
     }
-    let content_type = str::from_utf8(self.content_type.as_ref()?).ok()?;
+    let content_type = str::from_utf8(self.content_type.as_ref()?).ok()?.trim();
 
     // Require a '/' to filter out binary data that happens to be valid UTF-8
     if !content_type.contains('/') {
@@ -364,5 +364,11 @@ mod tests {
     let png_header = b"\x89PNG\r\n\x1a\n".to_vec();
     let inscription = Inscription::new(Some(png_header), None, BTreeMap::new());
     assert_eq!(inscription.content_type(), None);
+  }
+
+  #[test]
+  fn content_type_trims_whitespace() {
+    let inscription = Inscription::new(Some(b"image/avif\r\n".to_vec()), None, BTreeMap::new());
+    assert_eq!(inscription.content_type(), Some("image/avif"));
   }
 }

--- a/src/inscriptions/inscription.rs
+++ b/src/inscriptions/inscription.rs
@@ -212,7 +212,14 @@ impl Inscription {
     if self.delegate_id().is_some() {
       return None;
     }
-    str::from_utf8(self.content_type.as_ref()?).ok()
+    let content_type = str::from_utf8(self.content_type.as_ref()?).ok()?;
+
+    // Require a '/' to filter out binary data that happens to be valid UTF-8
+    if !content_type.contains('/') {
+      return None;
+    }
+
+    Some(content_type)
   }
 
   pub fn to_p2sh_unlock(&self) -> Script {
@@ -338,5 +345,24 @@ mod tests {
   fn compress_no_body() {
     let mut inscription = Inscription::new(Some(b"text/plain".to_vec()), None, BTreeMap::new());
     assert_eq!(inscription.compress().unwrap(), 0);
+  }
+
+  #[test]
+  fn content_type_valid() {
+    let inscription = Inscription::new(Some(b"image/png".to_vec()), None, BTreeMap::new());
+    assert_eq!(inscription.content_type(), Some("image/png"));
+  }
+
+  #[test]
+  fn content_type_rejects_missing_slash() {
+    let inscription = Inscription::new(Some(b"not a mime type".to_vec()), None, BTreeMap::new());
+    assert_eq!(inscription.content_type(), None);
+  }
+
+  #[test]
+  fn content_type_rejects_binary() {
+    let png_header = b"\x89PNG\r\n\x1a\n".to_vec();
+    let inscription = Inscription::new(Some(png_header), None, BTreeMap::new());
+    assert_eq!(inscription.content_type(), None);
   }
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -2751,6 +2751,19 @@ mod tests {
   }
 
   #[test]
+  fn content_response_bad_content_type() {
+    let (headers, body) = Server::content_response(Inscription::new(
+      Some("\n".as_bytes().to_vec()),
+      Some(Vec::new()),
+      BTreeMap::new(),
+    ))
+    .unwrap();
+
+    assert_eq!(headers["content-type"], "application/octet-stream");
+    assert!(body.is_empty());
+  }
+
+  #[test]
   fn text_preview() {
     let server = TestServer::new();
     server.mine_blocks(1);

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1099,9 +1099,8 @@ impl Server {
       header::CONTENT_TYPE,
       inscription
         .content_type()
-        .unwrap_or("application/octet-stream")
-        .parse()
-        .unwrap(),
+        .and_then(|content_type| content_type.parse().ok())
+        .unwrap_or(HeaderValue::from_static("application/octet-stream")),
     );
     headers.insert(
       header::CONTENT_SECURITY_POLICY,


### PR DESCRIPTION
## Summary
- Reject malformed `content_type` values that don't contain `/` (e.g. binary PNG data that passes UTF-8 check)
- Fix potential panic in `content_response` when content type can't be parsed as HTTP header value (upstream fix from ordinals/ord#2326)

Closes #62